### PR TITLE
Fix vercel deployment 404 error

### DIFF
--- a/example/vercel.json
+++ b/example/vercel.json
@@ -19,6 +19,10 @@
       "dest": "pages/index.html"
     },
     {
+      "src": "/ui",
+      "dest": "pages/ui.html"
+    },
+    {
       "src": "/ui/(.*)",
       "dest": "pages/ui.html"
     },


### PR DESCRIPTION
原来访问http://{{serverURL}}/ui 会出现404错误