### PR TITLE
feat(vercel): Telegram notification support

### DIFF
--- a/docs/en/server/notification.md
+++ b/docs/en/server/notification.md
@@ -31,3 +31,5 @@ We use Telegram bot to send comment notification. You need to set the following 
 - `TG_BOT_TOKEN`：Telegram bot token to access the HTTP API. Create a bot with [@BotFather](https://t.me/BotFather) to get this token.
 - `TG_CHAT_ID`：The `chat_id` of the receiver. It can be an user, a channel or a group. [@userinfobot](https://t.me/userinfobot) will display this `chat_id` when you forward a message to it.
 - `AUTHOR_EMAIL`：The blogger’s email is used to distinguish whether the posted comment is posted by the blogger himself. If it is posted by the blogger, there will be no reminder notification.
+- `SITE_NAME`：Your site name, it will be displayed in notification message.
+- `SITE_URL`：Your site url, it will be displayed in notification message.

--- a/docs/en/server/notification.md
+++ b/docs/en/server/notification.md
@@ -23,3 +23,10 @@ We use [Server Chan](http://sc.ftqq.com/3.version) to wechat notification. You n
 - `AUTHOR_EMAIL`：The blogger’s email is used to distinguish whether the posted comment is posted by the blogger himself. If it is posted by the blogger, there will be no reminder notification.
 - `SITE_NAME`：Your site name, it will be displayed in notification message.
 - `SITE_URL`：Your site url, it will be displayed in notification message.
+
+## Telegram Notification
+
+We use Telegram bot to send comment notification. You need to set the following env first.
+
+- `TG_BOT_TOKEN`：Telegram bot token to access the HTTP API. Create a bot with [@BotFather](https://t.me/BotFather) to get this token.
+- `TG_CHAT_ID`：The `chat_id` of the receiver. It can be an user, a channel or a group. [@userinfobot](https://t.me/userinfobot) will display this `chat_id` when you forward a message to it.

--- a/docs/en/server/notification.md
+++ b/docs/en/server/notification.md
@@ -30,3 +30,4 @@ We use Telegram bot to send comment notification. You need to set the following 
 
 - `TG_BOT_TOKEN`：Telegram bot token to access the HTTP API. Create a bot with [@BotFather](https://t.me/BotFather) to get this token.
 - `TG_CHAT_ID`：The `chat_id` of the receiver. It can be an user, a channel or a group. [@userinfobot](https://t.me/userinfobot) will display this `chat_id` when you forward a message to it.
+- `AUTHOR_EMAIL`：The blogger’s email is used to distinguish whether the posted comment is posted by the blogger himself. If it is posted by the blogger, there will be no reminder notification.

--- a/docs/server/notification.md
+++ b/docs/server/notification.md
@@ -31,3 +31,5 @@ Telegram 通知通过 Telegram bot 机器人实现，需要在环境变量中配
 - `TG_BOT_TOKEN`：Telegram 机器人用于访问 HTTP API 的 token，通过 [@BotFather](https://t.me/BotFather) 创建机器人获取。
 - `TG_CHAT_ID`：Telegram 机器人发送消息对象的 `chat_id`，可以是单一用户、频道、群组，通过 [@userinfobot](https://t.me/userinfobot) 获取。
 - `AUTHOR_EMAIL`：博主邮箱，用来区分发布的评论是否是博主本身发布的。如果是博主发布的则不进行提醒通知。
+- `SITE_NAME`：网站名称，用于在消息中显示。
+- `SITE_URL`：网站地址，用于在消息中显示。

--- a/docs/server/notification.md
+++ b/docs/server/notification.md
@@ -28,5 +28,6 @@
 
 Telegram 通知通过 Telegram bot 机器人实现，需要在环境变量中配置以下几个：
 
-- `TG_BOT_TOKEN`：Telegram 机器人用于访问 HTTP API 的 token，通过 [@BotFather](https://t.me/BotFather) 创建机器人获取
-- `TG_CHAT_ID`：Telegram 机器人发送消息对象的 `chat_id`，可以是单一用户、频道、群组，通过 [@userinfobot](https://t.me/userinfobot) 获取
+- `TG_BOT_TOKEN`：Telegram 机器人用于访问 HTTP API 的 token，通过 [@BotFather](https://t.me/BotFather) 创建机器人获取。
+- `TG_CHAT_ID`：Telegram 机器人发送消息对象的 `chat_id`，可以是单一用户、频道、群组，通过 [@userinfobot](https://t.me/userinfobot) 获取。
+- `AUTHOR_EMAIL`：博主邮箱，用来区分发布的评论是否是博主本身发布的。如果是博主发布的则不进行提醒通知。

--- a/docs/server/notification.md
+++ b/docs/server/notification.md
@@ -23,3 +23,10 @@
 - `AUTHOR_EMAIL`：博主邮箱，用来区分发布的评论是否是博主本身发布的。如果是博主发布的则不进行提醒通知。
 - `SITE_NAME`：网站名称，用于在消息中显示。
 - `SITE_URL`：网站地址，用于在消息中显示。
+
+## Telegram 通知
+
+Telegram 通知通过 Telegram bot 机器人实现，需要在环境变量中配置以下几个：
+
+- `TG_BOT_TOKEN`：Telegram 机器人用于访问 HTTP API 的 token，通过 [@BotFather](https://t.me/BotFather) 创建机器人获取
+- `TG_CHAT_ID`：Telegram 机器人发送消息对象的 `chat_id`，可以是单一用户、频道、群组，通过 [@userinfobot](https://t.me/userinfobot) 获取

--- a/packages/server/src/service/notify.js
+++ b/packages/server/src/service/notify.js
@@ -81,8 +81,8 @@ module.exports = class extends think.Service {
   }
   
   async telegram({contentTG}, self, parent) {
-    const {TG_TOKEN, CHAT_ID, SITE_NAME, SITE_URL} = process.env;
-    if(!TG_TOKEN) {
+    const {TG_BOT_TOKEN, TG_CHAT_ID, SITE_NAME, SITE_URL} = process.env;
+    if(!TG_BOT_TOKEN || !TG_CHAT_ID) {
       return false;
     }
 
@@ -101,11 +101,11 @@ module.exports = class extends think.Service {
     contentTG = contentTG.replace(/<img src="(https?:[\s\S]*).png" alt="[\s\S]*">/g,' ')
 
     return request({
-      uri: `https://api.telegram.org/bot${TG_TOKEN}/sendMessage`,
+      uri: `https://api.telegram.org/bot${TG_BOT_TOKEN}/sendMessage`,
       method: 'POST',
       form: {
         text: contentTG,
-        chat_id: CHAT_ID,
+        chat_id: TG_CHAT_ID,
         parse_mode: 'MarkdownV2'
       },
       json: true


### PR DESCRIPTION
实现了 Telegram 机器人的评论通知功能，文档那边也相应修改了。

不过实现的过程个人感觉十分简陋。评论通知这里读取的变量 `{{self.comment | safe}}` 已经被渲染成 HTML 了，如果直接发送该段内容，Telegram 有可能不会接受而报错，因为其[只支持部分 HTML 标签](https://core.telegram.org/bots/api#html-style)。

Telegram 机器人是可以接受 [MarkDown 内容](https://core.telegram.org/bots/api#markdownv2-style) 的，所以我这里干脆把发送消息的内容写成了 MarkDown，然而因为变量 `{{self.comment | safe}}` 依然是 HTML，我这里只能做了一点简单的处理：把 `<p>`、换行符、表情这几个剔除，然后让评论内容变成代码格式。这样发送消息时候就不会报错，消息内容也会简洁一些。

当然最好的方式是，直接把用户在评论框中的 MarkDown 评论传递给 Telegram 机器人，这样就不会出现上面这样评论经过了 MarkDown-HTML-MarkDown 几个阶段转换的过程了。技术有限，我是搞不定了😂😂 如果可以的话可以进一步改进～

评论通知效果如下：

<img width="383" alt="image" src="https://user-images.githubusercontent.com/19180725/102727861-688fa600-4363-11eb-97bc-ab50ef1e7f60.png">