### PR TITLE
fix(vercel): fix Telegram notify bug & comment admin index error

### DIFF
--- a/packages/server/src/controller/index.js
+++ b/packages/server/src/controller/index.js
@@ -15,7 +15,7 @@ module.exports = class extends think.Controller {
         new Waline({
           el: '#waline',
           path: '/',
-          serverURL: location.protocol + '//' + location.host + location.pathname.replace(/\/+$/, '')
+          serverURL: location.protocol + '//' + location.host + location.pathname.replace(/\\/+$/, '')
         });
       </script>
     </body>

--- a/packages/server/src/service/notify.js
+++ b/packages/server/src/service/notify.js
@@ -86,9 +86,12 @@ module.exports = class extends think.Service {
 
 *{{self.nick}}* 回复说：
 
+\`\`\`
 {{self.rawComment}}
+\`\`\`
+*邮箱：*\`{{self.mail}}\`  *审核：*{{self.status}} 
 
-您可以点击[查看回复的完整內容]({{site.postUrl}})`;
+评论仅显示 Markdown 源代码，您可以点击[查看回复的完整內容]({{site.postUrl}})`;
 
     const {TG_BOT_TOKEN, TG_CHAT_ID, SITE_NAME, SITE_URL} = process.env;
     if(!TG_BOT_TOKEN || !TG_CHAT_ID) {

--- a/packages/server/src/service/notify.js
+++ b/packages/server/src/service/notify.js
@@ -81,17 +81,20 @@ module.exports = class extends think.Service {
   }
   
   async telegram(self, parent) {
+    const rawComment = self.rawComment.replace(/\!\[(.*?)\]\((.*?)\)/g,' ');
     const contentTG = `
-💬 *[{{site.name}}]({{site.url}}) 上有新评论啦*
+💬 *[{{site.name}}]({{site.url}}) 有新评论啦*
 
 *{{self.nick}}* 回复说：
 
 \`\`\`
-{{self.rawComment}}
+` + rawComment + `
 \`\`\`
-*邮箱：*\`{{self.mail}}\`  *审核：*{{self.status}} 
+*邮箱：*\`{{self.mail}}\`
 
-评论仅显示 Markdown 源代码，您可以点击[查看回复的完整內容]({{site.postUrl}})`;
+*审核：*{{self.status}} 
+
+评论仅显示源码，点击[查看完整內容]({{site.postUrl}})`;
 
     const {TG_BOT_TOKEN, TG_CHAT_ID, SITE_NAME, SITE_URL} = process.env;
     if(!TG_BOT_TOKEN || !TG_CHAT_ID) {


### PR DESCRIPTION
- 看了一下 Telegram 通知的文档，感觉其实对 MarkDown 语法也限制很多，不经过特别处理很容易报错。干脆直接把评论内容的 MarkDown 源代码以代码格式都发送出去好了（为了通知内容简洁考虑，删除表情包的内容），现在这样起码不至于因为某些奇奇怪怪的格式而报错。
- 评论管理首页没法访问了，应该是不能正确读取 serverUrl 导致的，已修复。

<img width="364" alt="image" src="https://user-images.githubusercontent.com/19180725/102841786-8aab2600-4440-11eb-8480-791dfb99b212.png">
