### PR TITLE
fix(vercel): QQ and Tg notification layout

### DIFF
--- a/packages/server/src/service/notify.js
+++ b/packages/server/src/service/notify.js
@@ -86,7 +86,7 @@ module.exports = class extends think.Service {
       return false;
     }
 
-    self.comment = self.comment
+    self.commentQQ = self.comment
       .replace(/<a href="(.*?)">(.*?)<\/a>/g, "\n[$2] $1\n")
       .replace(/<[^>]+>/g, '');
     
@@ -104,8 +104,7 @@ module.exports = class extends think.Service {
 
 {{self.nick}} 回复说：
 
-{{self.comment}}
-
+{{self.commentQQ}}
 邮箱：{{self.mail}}
 审核：{{self.status}} 
 
@@ -126,18 +125,16 @@ module.exports = class extends think.Service {
     let commentLink = "";
     const href = self.comment.match(/<a href="(.*?)">(.*?)<\/a>/g);
     if (href !== null) {
-      for (var i = 0, j = 0; i < href.length; i++) {
-        href[i] = href[i].replace(/<a href="(.*?)">(.*?)<\/a>/g, "$1");
-        j = i + 1;
-        href[i] = "[链接" + j + "](" + href[i] + ")  ";
+      for (var i = 0; i < href.length; i++) {
+        href[i] = '[Link: ' + href[i].replace(/<a href="(.*?)">(.*?)<\/a>/g, "$2") + '](' + href[i].replace(/<a href="(.*?)">(.*?)<\/a>/g, "$1") + ')  ';
         commentLink = commentLink + href[i];
       }
     }
     if (commentLink != "") {
-      commentLink = `\n`+ commentLink + `\n`;
+      commentLink = `\n` + commentLink + `\n`;
     }
-    self.comment = self.comment
-      .replace(/<a href="(.*?)">(.*?)<\/a>/g, '\[链接 $2\]')
+    self.commentTG = self.comment
+      .replace(/<a href="(.*?)">(.*?)<\/a>/g, '\[Link:$2\]')
       .replace(/<[^>]+>/g, '');
     self.commentLink = commentLink;
 
@@ -147,11 +144,9 @@ module.exports = class extends think.Service {
 *{{self.nick}}* 回复说：
 
 \`\`\`
-{{self.comment}}
+{{self.commentTG-}}
 \`\`\`
-
-{{self.commentLink}}
-
+{{-self.commentLink}}
 *邮箱：*\`{{self.mail}}\`
 *审核：*{{self.status}} 
 


### PR DESCRIPTION
- 之前同时开启 QQ 和 Telegram 通知时候，专门为 Telegram 设置的评论内容会被覆盖，所以各自给了变量名。
- 此外调整了布局，减少了通知内容出现的空行，更为美观了。
- Telegram 通知内容中显示评论内部链接的内容是中文且不在变量里，都进行了如下修改：链接 -> Link ，或许可以便于以后实现通知内容的国际化（逃