### PR TITLE
feat: add client login support

### DIFF
--- a/assets/waline.pgsql
+++ b/assets/waline.pgsql
@@ -3,6 +3,7 @@ CREATE SEQUENCE wl_comment_seq;
 
 CREATE TABLE wl_comment (
   id int check (id > 0) NOT NULL DEFAULT NEXTVAL ('wl_comment_seq'),
+  user_id int DEFAULT NULL,
   comment text,
   insertedAt timestamp(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
   ip varchar(100) DEFAULT '',

--- a/assets/waline.sql
+++ b/assets/waline.sql
@@ -13,6 +13,7 @@ SET NAMES utf8mb4;
 
 CREATE TABLE `wl_Comment` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) DEFAULT NULL,
   `comment` text,
   `insertedAt` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `ip` varchar(100) DEFAULT '',

--- a/packages/admin/src/store/user.js
+++ b/packages/admin/src/store/user.js
@@ -28,7 +28,7 @@ export const user = createModel({
           localStorage.setItem('TOKEN', token);
         }
         if(window.opener) {
-          window.opener.postMessage({type: 'userInfo', data: {token, ...user}}, '*');
+          window.opener.postMessage({type: 'userInfo', data: {token, remember, ...user}}, '*');
         }
       }
       return dispatch.user.setUser(user);

--- a/packages/admin/src/store/user.js
+++ b/packages/admin/src/store/user.js
@@ -14,6 +14,9 @@ export const user = createModel({
       if(!user) {
         return;
       }
+      if(window.opener) {
+        window.opener.postMessage({type: 'userInfo', data: user}, '*');
+      }
       return dispatch.user.setUser(user);
     },
     async login({email, password, remember}) {
@@ -23,6 +26,9 @@ export const user = createModel({
         sessionStorage.setItem('TOKEN', token);
         if(remember) {
           localStorage.setItem('TOKEN', token);
+        }
+        if(window.opener) {
+          window.opener.postMessage({type: 'userInfo', data: {token, ...user}}, '*');
         }
       }
       return dispatch.user.setUser(user);

--- a/packages/client/src/components/CommentBox.js
+++ b/packages/client/src/components/CommentBox.js
@@ -266,18 +266,22 @@ export default function({
         ) : null}
         <div className="vleft vlogin">
           {!ctx.userInfo.token ? (
-            <a className="vlogin-btn" onClick={onLogin}>登录</a>
+            <a className="vlogin-btn" onClick={onLogin}>{ctx.locale.login}</a>
           ) : (
             <div className="vlogin-info">
               <div className="vlogin-avatar">
-                <img src="https://gravatar.loli.net/avatar/9a17b77cbecfb67b12e8866ceebd0095?d=mp" alt="" className="vimg"/>
-                <div className="vlogin-logout-btn" onClick={onLogout}>
+                <img src={ctx.gravatarSetting.cdn + comment.mailMd5 + ctx.gravatarSetting.params} alt="" className="vimg"/>
+                <div 
+                  title={ctx.locale.logout}
+                  className="vlogin-logout-btn" 
+                  onClick={onLogout}
+                >
                   <svg class="vicon" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" width="14" height="14">
                     <path d="M568.569 512l170.267-170.267c15.556-15.556 15.556-41.012 0-56.569s-41.012-15.556-56.569 0L512 455.431 341.733 285.165c-15.556-15.556-41.012-15.556-56.569 0s-15.556 41.012 0 56.569L455.431 512 285.165 682.267c-15.556 15.556-15.556 41.012 0 56.569 15.556 15.556 41.012 15.556 56.569 0L512 568.569l170.267 170.267c15.556 15.556 41.012 15.556 56.569 0 15.556-15.556 15.556-41.012 0-56.569L568.569 512z"></path>
                   </svg>
                 </div>
               </div>
-              <div className="vlogin-nick">怡红公子</div>
+              <div className="vlogin-nick">{ctx.userInfo.display_name}</div>
             </div>
           )}
         </div>

--- a/packages/client/src/components/CommentBox.js
+++ b/packages/client/src/components/CommentBox.js
@@ -228,12 +228,13 @@ export default function({
       if(data.data.token) {
         handler.close();
         ctx.setUserInfo(data.data);
-        sessionStorage.setItem('WALINE_USER', JSON.stringify(data.data));
+        (data.data.remember ? localStorage : sessionStorage).setItem('WALINE_USER', JSON.stringify(data.data));
       }
     })
   }, []);
   const onLogout = useCallback(e => {
     ctx.setUserInfo({});
+    localStorage.setItem('WALINE_USER', '');
     sessionStorage.setItem('WALINE_USER', '');
   }, []);
 

--- a/packages/client/src/context.js
+++ b/packages/client/src/context.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import locales from './i18n';
 
 const emojiCDN = 'https://img.t.sinajs.cn/t4/appstyle/expression/ext/normal/';
@@ -88,7 +88,11 @@ export const ConfigContext = React.createContext({
   locale: {},
   emojiCDN,
   emojiMaps,
-  gravatarSetting
+	gravatarSetting,
+	userInfo: {
+		nick: '',
+		mail: ''
+	}
 });
 
 export default function Context(props) {
@@ -101,6 +105,12 @@ export default function Context(props) {
 			locale[k] = props.langMode[k];
 		}
 	}
+
+	let initUser = {};
+	try {
+		initUser = JSON.parse((localStorage || sessionStorage).getItem('WALINE_USER')) || {};
+	} catch(e) {}
+	const [userInfo, setUserInfo] = useState(initUser);
 
   const context = {
     locales,
@@ -120,7 +130,9 @@ export default function Context(props) {
         method: 'POST',
         body: formData
       }).then(resp => resp.json()).then(resp => resp.data.url);
-    }
+		},
+		userInfo,
+		setUserInfo
   };
 
   return (

--- a/packages/client/src/context.js
+++ b/packages/client/src/context.js
@@ -108,7 +108,8 @@ export default function Context(props) {
 
 	let initUser = {};
 	try {
-		initUser = JSON.parse((localStorage || sessionStorage).getItem('WALINE_USER')) || {};
+		const KEY = 'WALINE_USER';
+		initUser = JSON.parse(localStorage.getItem(KEY) || sessionStorage.getItem(KEY)) || {};
 	} catch(e) {}
 	const [userInfo, setUserInfo] = useState(initUser);
 

--- a/packages/client/src/i18n/en.js
+++ b/packages/client/src/i18n/en.js
@@ -24,6 +24,8 @@ export default {
   uploading: "Uploading ...",
   uploadDone: "Upload completed!",
   busy: "Submit is busy, please wait...",
+  login: "Login",
+  logout: "logout",
   "code-98": "Valine initialization failed, please check your version of av-min.js.",
   "code-99": "Valine initialization failed, Please check the `el` element in the init method.",
   "code-100": "Valine initialization failed, Please check your appId and appKey.",

--- a/packages/client/src/i18n/jp.js
+++ b/packages/client/src/i18n/jp.js
@@ -24,6 +24,8 @@ export default {
   uploading: "アップロード中...",
   uploadDone: "アップロードが完了しました!",
   busy: "20 秒間隔で提出してください    ...",
+  login: "ログインする",
+  logout: "ログアウト",
   "code-98": "ロードエラーです。av-min.js のバージョンを確認してください.",
   "code-99": "ロードエラーです。initにある`el`エレメントを確認ください.",
   "code-100": "ロードエラーです。AppIdとAppKeyを確認ください.",

--- a/packages/client/src/i18n/zh-CN.js
+++ b/packages/client/src/i18n/zh-CN.js
@@ -24,6 +24,8 @@ export default {
   uploading: "正在传输...",
   uploadDone: "传输完成!",
   busy: "操作频繁，请稍候再试...",
+  login: "登錄",
+  logout: "退出",
   "code-98": "Valine 初始化失败，请检查 av-min.js 版本",
   "code-99": "Valine 初始化失败，请检查init中的`el`元素.",
   "code-100": "Valine 初始化失败，请检查你的AppId和AppKey.",

--- a/packages/client/src/i18n/zh-TW.js
+++ b/packages/client/src/i18n/zh-TW.js
@@ -24,6 +24,8 @@ export default {
   uploading: "正在上傳...",
   uploadDone: "上傳完成!",
   busy: "操作頻繁，請稍候再試...",
+  login: "登录",
+  logout: "退出",
   "code-98": "Valine 初始化失敗，請檢查 av-min.js 版本",
   "code-99": "Valine 初始化失敗，請檢查init中的`el`元素.",
   "code-100": "Valine 初始化失敗，請檢查你的AppId和AppKey.",

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -182,9 +182,11 @@
 	background: transparent
 }
 
+.v[data-class=v] .vheader {
+	padding-bottom: 10px;
+}
 .v[data-class=v] .vwrap .vedit {
 	position: relative;
-	padding-top: 10px
 }
 
 .v[data-class=v] .vwrap .cancel-reply-btn {
@@ -375,7 +377,8 @@
 	display: block
 }
 
-.v[data-class=v] .vcards .vcard .vimg {
+.v[data-class=v] .vcards .vcard .vimg,
+.v[data-class=v] .vlogin .vimg {
 	width: 3.125em;
 	height: 3.125em;
 	float: left;
@@ -658,6 +661,46 @@
 .theme__dark .v[data-class=v] .vcards .vcard .vcontent.expand:after,
 [data-theme=dark] .v[data-class=v] .vcards .vcard .vcontent.expand:after {
 	background: rgba(0, 0, 0, .7)
+}
+
+.v[data-class=v] .vleft {
+	float: left;
+	text-align: center;
+	margin-right: .7525em;
+}
+.v[data-class=v] .vright {
+	overflow: hidden;
+}
+.v[data-class=v] .vlogin-btn {
+	width: 3.572em;
+	height: 3.572em;
+	text-align: center;
+	line-height: 3.572em;
+	display: block;
+	border-radius: 50%;
+	border: 1px dashed #dedede;
+	font-size: 14px;
+	color: #555;
+}
+.v[data-class=v] .vlogin-avatar {
+	position: relative;
+}
+.v[data-class=v] .vlogin-avatar .vimg {
+	margin-right: 0;
+}
+.v[data-class=v] .vlogin-logout-btn {
+	position: absolute;
+	background: #FFF;
+	line-height: 0;
+	font-size: 14px;
+	right: 3px;
+	top: -3px;
+	border: 1px solid #f5f5f5;
+	border-radius: 50%;
+}
+.v[data-class=v] .vlogin-nick {
+	font-size: 12px;
+	color: #1abc9c;
 }
 
 @media (prefers-color-scheme:dark) {

--- a/packages/client/src/utils/fetch.js
+++ b/packages/client/src/utils/fetch.js
@@ -13,12 +13,13 @@ export function fetchList({serverURL, path, page, pageSize}) {
   return fetch(url).then(resp => resp.json());
 }
 
-export function postComment({serverURL, comment}) {
+export function postComment({serverURL, token, comment}) {
   const url = `${serverURL}/comment`;
   return fetch(url, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
     },
     body: JSON.stringify(comment)
   }).then(resp => resp.json());

--- a/packages/server/src/controller/comment.js
+++ b/packages/server/src/controller/comment.js
@@ -164,7 +164,8 @@ module.exports = class extends BaseRest {
       link, mail, nick, pid, rid, ua, url, 
       ip: this.ctx.ip,
       insertedAt: new Date(),
-      comment: marked(comment)
+      comment: marked(comment),
+      user_id: this.ctx.state.userInfo.objectId
     };
     if(pid) {
       data.comment = data.comment.replace('<p>', `<p><a class="at" href="#${pid}">@${at}</a> , `);

--- a/packages/server/src/controller/token.js
+++ b/packages/server/src/controller/token.js
@@ -1,4 +1,5 @@
 const jwt = require('jsonwebtoken');
+const helper = require('think-helper');
 const { PasswordHash } = require('phpass');
 const BaseRest = require('./rest');
 
@@ -27,6 +28,7 @@ module.exports = class extends BaseRest {
     return this.success({
       ...user[0], 
       password: null,
+      mailMd5: helper.md5(user[0].email),
       token: jwt.sign(user[0].email, this.config('jwtKey'))
     });
   }


### PR DESCRIPTION
1. Add login buttion in `@vercel/client`,  it will open a new window to load login url when you click.
2. The login page is same with admin dashboard. The login window will be closed after login success, also user info will passed to original page.
3. The original page will show user info in the page after received user info. All info input box will be hidden at the same time.
4. Then you can post your comment just input your comment text.
5. We can get user id by the login token at the backed, and we will add a new filed `user_id` to storage it.

---

1. 客户端增加登录按钮，点击登录按钮后会开启登录的新窗口。
2. 登录窗口复用了后台的登录，登录完成后会关闭当前窗口，并将用户信息传递给原页面。
3. 原页面获取到用户信息后展示，同时隐藏需要输入用户信息的输入框。
4. 此时输入评论内容即可直接发送了
5. 后台会通过登录密钥获取到用户 ID，并在数据中新增了 `user_id` 的关联字段。

![image](https://user-images.githubusercontent.com/424491/103455656-d48de900-4d29-11eb-8ae7-96d333593e64.png)

