### PR TITLE
把在TCB部署的名称改成Waline

### DIFF
--- a/packages/tcb-starter/cloudbaserc.json
+++ b/packages/tcb-starter/cloudbaserc.json
@@ -3,7 +3,7 @@
   "envId": "{{envId}}",
   "$schema": "https://framework-1258016615.tcloudbaseapp.com/schema/latest.json",
   "framework": {
-    "name": "ThinkJS",
+    "name": "Waline",
     "plugins": {
       "node": {
         "use": "@cloudbase/framework-plugin-node",


### PR DESCRIPTION
一键部署下来发现应用名称是 ThinkJS，还是改成Waline好区分一点