### PR TITLE
delete space in contentQQ

### DIFF
--- a/packages/server/src/service/notify.js
+++ b/packages/server/src/service/notify.js
@@ -87,6 +87,8 @@ module.exports = class extends think.Service {
     }
 
     const comment = self.comment
+      .replace(/<a href="(.*?)">(.*?)<\/a>/g, "\n[$2] $1\n")
+      .replace(/<[^>]+>/g, '');
     
     const data = {
       self: {
@@ -101,7 +103,7 @@ module.exports = class extends think.Service {
       }
     };
 
-    const contentQQ = `💬 {{site.name}} 有新评论啦
+    const contentQQ = `💬 {{site.name|safe}} 有新评论啦
       {{self.nick}} 评论道：
       {{self.comment}}
       邮箱：{{self.mail}}

--- a/packages/server/src/service/notify.js
+++ b/packages/server/src/service/notify.js
@@ -87,8 +87,6 @@ module.exports = class extends think.Service {
     }
 
     const comment = self.comment
-      .replace(/<a href="(.*?)">(.*?)<\/a>/g, "\n[$2] $1\n")
-      .replace(/<[^>]+>/g, '');
     
     const data = {
       self: {
@@ -104,15 +102,12 @@ module.exports = class extends think.Service {
     };
 
     const contentQQ = `💬 {{site.name}} 有新评论啦
-
-{{self.nick}} 回复说：
-
-{{self.comment}}
-邮箱：{{self.mail}}
-审核：{{self.status}} 
-
-仅供评论预览，查看完整內容：
-{{site.postUrl}}`;
+      {{self.nick}} 评论道：
+      {{self.comment}}
+      邮箱：{{self.mail}}
+      状态：{{self.status}} 
+      仅供评论预览，查看完整內容：
+      {{site.postUrl}}`;
 
     return request({
       uri: `https://qmsg.zendee.cn/send/${QMSG_KEY}`,


### PR DESCRIPTION
在fork的仓库部署后更改不会生效，所以修改后就直接pr了，请公子看看这样是否可行。
更改有：1.去除评论内容的转义；2.去除多余的空行，使推送文本更紧凑和高效。