### PR TITLE
使用 GitHub Actions 构建docker镜像

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,50 @@
+name: "[docker] CI for releases"
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "packages/server/*"
+
+jobs:
+  path-context:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push alpine
+        uses: docker/build-push-action@v2
+        with:
+          file: ./packages/server/Dockerfile.alpine
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: |
+            lizheming/waline:alpine
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+      - name: Build and push debian
+        uses: docker/build-push-action@v2
+        with:
+          file: ./packages/server/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: |
+            lizheming/waline:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,39 @@
+name: "[docker] CI for test"
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - "packages/server/*"
+
+jobs:
+  path-context:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Build alpine
+        uses: docker/build-push-action@v2
+        with:
+          file: ./packages/server/Dockerfile.alpine
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max
+      - name: Build debian
+        uses: docker/build-push-action@v2
+        with:
+          file: ./packages/server/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache,mode=max

--- a/packages/server/Dockerfile.alpine
+++ b/packages/server/Dockerfile.alpine
@@ -6,10 +6,16 @@ RUN set -eux; \
 	# npm config set registry https://registry.npm.taobao.org; \
 	npm install --production --silent @waline/vercel
 
-FROM node:lts-buster-slim
+FROM node:lts-alpine
 WORKDIR /app
 ENV TZ Asia/Shanghai
 ENV NODE_ENV production
+RUN set -eux; \
+	# sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories; \
+	apk add --no-cache bash; \
+	apk add --no-cache --virtual .build-deps alpine-conf; \
+	setup-timezone -z ${TZ}; \
+	apk del --no-network .build-deps
 COPY --from=build /app .
 EXPOSE 8360
 CMD ["node", "node_modules/@waline/vercel/vanilla.js"]

--- a/packages/server/docker-compose.yml
+++ b/packages/server/docker-compose.yml
@@ -1,0 +1,20 @@
+# docker-compose.yml
+version: "3"
+
+services:
+  waline:
+    container_name: waline
+    image: lizheming/waline:latest
+    restart: always
+    ports:
+      - 127.0.0.1:8360:8360
+    volumes:
+      - ${PWD}/data:/app/data
+    environment:
+      TZ: "Asia/Shanghai"
+      SQLITE_PATH: "/app/data"
+      JWT_TOKEN: "Your token"
+      SITE_NAME: "Your site name"
+      SITE_URL: "https://example.com"
+      SECURE_DOMAINS: "example.com"
+      AUTHOR_EMAIL: "mail@example.com"


### PR DESCRIPTION
> 是否可以参考 [docker-waline](https://github.com/uuznn/docker-waline) 的构建方法。或者能否把仓库 [docker-waline](https://github.com/uuznn/docker-waline) 合并到 [walinejs](https://github.com/walinejs) 

## 使用 GitHub Actions 构建docker镜像

⚠  需要在 `secrets` 填写  ⚠
- DOCKERHUB_USERNAME 
- DOCKERHUB_TOKEN 

支持的架构：
- linux/amd64
- linux/arm64
- linux/arm/v7

支持的Docker容器：
- debian( latest )
- alpine

---

⚠ 需要停止使用 Docker Hub的构建。因为Docker Hub会对本仓库的每一次commit构建新版本，是完全没有必要的。
因此只对 `packages/server/*` 触发构建

---

## Dockerfile 和 Dockerfile.alpine

- 两个文件区分了 debian 和 alpine 的构建版本
- 取消使用仓库文件构建，转而使用 npm install 进行安装。⚠
- 因此 docker 版本会比推送到仓库时有一个版本的间隔。相比直接推送到 DockerHub 可以有一个冷静期
- 可以额外触发一次 workflow ci 推送最新版到 docker hub

## docker-compose.yml
- 添加了 docker compose 模板
